### PR TITLE
### Summary of Changes

### DIFF
--- a/AZFUNCFILEPROCESSINGADF/DataFlowExecutor.cs
+++ b/AZFUNCFILEPROCESSINGADF/DataFlowExecutor.cs
@@ -74,7 +74,7 @@ namespace AZFUNCFILEPROCESSINGADF
                 var binaryDataPipeParameters = new Dictionary<string, BinaryData>
                 {
                     { "inputFileName", BinaryData.FromString(JsonSerializer.Serialize(fileName))}, //inputPath is the parameter name in the pipeline
-                    { "outputFileName",BinaryData.FromString(JsonSerializer.Serialize($"{fileName}-OUTPUT")) }, //outputPath is the parameter name in the pipeline
+                    { "outputFileName",BinaryData.FromString(JsonSerializer.Serialize($"OUTPUT-{fileName}")) }, //outputPath is the parameter name in the pipeline
 
                 };
 


### PR DESCRIPTION
The code change modifies the format of the `outputFileName` parameter in the pipeline. Instead of appending "-OUTPUT" to the end of the original `fileName`, the new format prefixes "OUTPUT-" to the original `fileName`.

### List of Changes
1. **Modification of `outputFileName` Format**:
   - **Previous Format**: `fileName` + "-OUTPUT"
   - **New Format**: "OUTPUT-" + `fileName`
   - **Reference**: [Code Change Description]